### PR TITLE
Update version to 14.0 for runtime syn-nodejs-puppeteer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudwatch-synthetics-sdk-nodejs-puppeteer",
-  "version": "13.1.0",
+  "version": "14.0",
   "private": true,
   "license": "Apache-2.0",
   "author": {
@@ -11,8 +11,8 @@
   ],
   "devDependencies": {
     "tsd": "^0.25.0",
-    "typescript": "^4.4.4",
-    "puppeteer-core": "24.25.0",
+    "typescript": "^5.4.5",
+    "puppeteer-core": "24.34.0",
     "@types/node": "^20.10.0"
   },
   "dependencies": {

--- a/packages/synthetics-puppeteer/CHANGELOG.md
+++ b/packages/synthetics-puppeteer/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
 
+## 14.0
+* feature: TypeScript type definitions for Amazon CloudWatch Synthetics runtime version `syn-nodejs-puppeteer-14.0`
+
 ## 13.1.0
 * feature: Initial TypeScript type definitions for Amazon CloudWatch Synthetics runtime version `syn-nodejs-puppeteer-13.1`

--- a/packages/synthetics-puppeteer/package.json
+++ b/packages/synthetics-puppeteer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws/synthetics-puppeteer",
-  "version": "13.1.0",
+  "version": "14.0",
   "description": "Amazon CloudWatch Synthetics Type Support for syn-nodejs-puppeteer-* runtime",
   "main": "lib/index.d.ts",
   "types": "lib/index.d.ts",
@@ -28,7 +28,7 @@
     "puppeteer"
   ],
   "dependencies": {
-    "puppeteer-core": "24.25.0"
+    "puppeteer-core": "24.34.0"
   },
   "author": "Amazon Web Services",
   "license": "Apache-2.0"


### PR DESCRIPTION
*Description of changes:*

Update for TypeScript type definitions for Amazon CloudWatch Synthetics runtime version `syn-nodejs-puppeteer-14.0`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
