### PR TITLE
Update version to 15.0 for syn-nodejs-puppeteer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudwatch-synthetics-sdk-nodejs-puppeteer",
-  "version": "14.0.0",
+  "version": "15.0.0",
   "private": true,
   "license": "Apache-2.0",
   "author": {
@@ -12,7 +12,7 @@
   "devDependencies": {
     "tsd": "^0.25.0",
     "typescript": "^5.4.5",
-    "puppeteer-core": "24.34.0",
+    "puppeteer-core": "24.37.5",
     "@types/node": "^20.10.0"
   },
   "dependencies": {

--- a/packages/synthetics-broken-link-checker-report/CHANGELOG.md
+++ b/packages/synthetics-broken-link-checker-report/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 15.0.0
+* feature: TypeScript type definitions for Amazon CloudWatch Synthetics runtime version `syn-nodejs-puppeteer-15.0`
+
 ## 14.0.0
 * feature: TypeScript type definitions for Amazon CloudWatch Synthetics runtime version `syn-nodejs-puppeteer-14.0`
 

--- a/packages/synthetics-broken-link-checker-report/package.json
+++ b/packages/synthetics-broken-link-checker-report/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws/synthetics-broken-link-checker-report",
-  "version": "14.0.0",
+  "version": "15.0.0",
   "description": "Amazon CloudWatch Synthetics Type Support for syn-nodejs-puppeteer-* runtime",
   "main": "lib/index.d.ts",
   "types": "lib/index.d.ts",
@@ -28,7 +28,7 @@
     "puppeteer"
   ],
   "peerDependencies": {
-    "@aws/synthetics-link": "14.0.0"
+    "@aws/synthetics-link": "15.0.0"
   },
   "author": "Amazon Web Services",
   "license": "Apache-2.0"

--- a/packages/synthetics-link/CHANGELOG.md
+++ b/packages/synthetics-link/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 15.0.0
+* feature: TypeScript type definitions for Amazon CloudWatch Synthetics runtime version `syn-nodejs-puppeteer-15.0`
+
 ## 14.0.0
 * feature: TypeScript type definitions for Amazon CloudWatch Synthetics runtime version `syn-nodejs-puppeteer-14.0`
 

--- a/packages/synthetics-link/package.json
+++ b/packages/synthetics-link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws/synthetics-link",
-  "version": "14.0.0",
+  "version": "15.0.0",
   "description": "Amazon CloudWatch Synthetics Type Support for syn-nodejs-puppeteer-* runtime",
   "main": "lib/index.d.ts",
   "types": "lib/index.d.ts",

--- a/packages/synthetics-log-helper/CHANGELOG.md
+++ b/packages/synthetics-log-helper/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 15.0.0
+* feature: TypeScript type definitions for Amazon CloudWatch Synthetics runtime version `syn-nodejs-puppeteer-15.0`
+
 ## 14.0.0
 * feature: TypeScript type definitions for Amazon CloudWatch Synthetics runtime version `syn-nodejs-puppeteer-14.0`
 

--- a/packages/synthetics-log-helper/package.json
+++ b/packages/synthetics-log-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws/synthetics-log-helper",
-  "version": "14.0.0",
+  "version": "15.0.0",
   "description": "Amazon CloudWatch Synthetics Type Support for syn-nodejs-puppeteer-* runtime",
   "main": "lib/index.d.ts",
   "types": "lib/index.d.ts",

--- a/packages/synthetics-logger/CHANGELOG.md
+++ b/packages/synthetics-logger/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 15.0.0
+* feature: TypeScript type definitions for Amazon CloudWatch Synthetics runtime version `syn-nodejs-puppeteer-15.0`
+
 ## 14.0.0
 * feature: TypeScript type definitions for Amazon CloudWatch Synthetics runtime version `syn-nodejs-puppeteer-14.0`
 

--- a/packages/synthetics-logger/package.json
+++ b/packages/synthetics-logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws/synthetics-logger",
-  "version": "14.0.0",
+  "version": "15.0.0",
   "description": "Amazon CloudWatch Synthetics Type Support for syn-nodejs-puppeteer-* runtime",
   "main": "lib/index.d.ts",
   "types": "lib/index.d.ts",

--- a/packages/synthetics-puppeteer/CHANGELOG.md
+++ b/packages/synthetics-puppeteer/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 15.0.0
+* feature: TypeScript type definitions for Amazon CloudWatch Synthetics runtime version `syn-nodejs-puppeteer-15.0`
+
 ## 14.0.0
 * feature: TypeScript type definitions for Amazon CloudWatch Synthetics runtime version `syn-nodejs-puppeteer-14.0`
 

--- a/packages/synthetics-puppeteer/package.json
+++ b/packages/synthetics-puppeteer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws/synthetics-puppeteer",
-  "version": "14.0.0",
+  "version": "15.0.0",
   "description": "Amazon CloudWatch Synthetics Type Support for syn-nodejs-puppeteer-* runtime",
   "main": "lib/index.d.ts",
   "types": "lib/index.d.ts",
@@ -28,7 +28,7 @@
     "puppeteer"
   ],
   "dependencies": {
-    "puppeteer-core": "24.34.0"
+    "puppeteer-core": "24.37.5"
   },
   "author": "Amazon Web Services",
   "license": "Apache-2.0"


### PR DESCRIPTION
*Description of changes:*

TypeScript type definitions for Amazon CloudWatch Synthetics runtime version `syn-nodejs-puppeteer-15.0`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
